### PR TITLE
Refocus GPT AI Assistant as a LINE personal assistant

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,88 +1,124 @@
 # AGENTS.md
 
-給 Codex 與其他 AI coding agents 在本專案工作時的指引。Claude Code 專屬補充見 [`CLAUDE.md`](CLAUDE.md)，兩者主要規則一致。
+本檔是 **SanHsien/gpt-ai-assistant** 的 AI coding agent 主要維護規則。Claude 專屬薄入口見 [`CLAUDE.md`](CLAUDE.md)，快速索引見 [`SKILL.md`](SKILL.md)；衝突時以本檔為準。
 
-## 專案宗旨
+## 專案定位
 
-`gpt-ai-assistant` 是一個 LINE 個人助理：透過 LINE Messaging API 收訊息，串接 OpenAI API 產生文字回覆、GPT Image 生圖與影像理解，並可經 SerpAPI 搜尋、Supabase 保存 durable 狀態及 Google Calendar 管理行程。以 serverless（Vercel 優先）方式部署，使用者自架、自備 API key 與 LINE channel。
+**GPT AI Assistant** 是可自架的 LINE 個人助理。LINE 是主要使用介面，OpenAI 是預設 AI provider；Supabase 提供 durable runtime，Google Calendar／Tasks、SerpAPI、Open-Meteo 等依功能設定整合。
 
-本 repo 源自 [`memochou1993/gpt-ai-assistant`](https://github.com/memochou1993/gpt-ai-assistant)（MIT），現為獨立維護 repository。
+本專案衍生自 [`memochou1993/gpt-ai-assistant`](https://github.com/memochou1993/gpt-ai-assistant)，保留 MIT License 與 attribution，現由 SanHsien 獨立維護。
 
-## 本專案的方向
+## 硬性產品邊界
 
-- **核心不變**：保留 OpenAI + LINE、自架、自備 API key；不整套重寫，也不任意更換預設供應商。
-- **已核准方向**：`5.0.0` 已完成 M1 真實 LINE 閉環；`6.0.0` 已完成 Supabase durable-only runtime、固定 queue、migration preflight、Google provider contract、最多 13 個 feature-aware LINE 快捷入口、完整 `指令` 清單、Node 24 container healthcheck、Express 5／Jest 30／ESLint 10 維護基線、Google Tasks dead sync job 安全恢復、週期行程當地鐘點校正、Google request／cron drain time budget、Calendar inbound 非展開系列同步，以及 LINE 桌面音訊檔轉錄、實際 content type 判斷與語音指令同音字容錯，並已通過集中 LINE／Google 驗收。`6.1.0` 再加上行程提前一天預設提醒、Calendar inbound v3 匯入 primary calendar 既存的未來 timed non-recurring Google-origin 行程、有期限任務提醒，以及 Dependabot／freshness 依賴維護閉環。進階能力仍不可跳過 scheduler、delivery idempotency、recurrence round-trip 與衝突政策各自堆疊。
-- 模型／API、fermi、參考專案與授權邊界也統一維護在 [`docs/ROADMAP.md`](docs/ROADMAP.md)；不要直接合併 fermi 原始碼。
-- 未來可能的 Claude 版助理仍是候選，可能開新專案或在此 repo 分支，方式待定。
-- **已排除方向**：不要嘗試用 OpenAI / ChatGPT 訂閱 OAuth 取代 API key；官方目前將 ChatGPT 訂閱與 API usage 分開計費與管理，Codex 的 ChatGPT sign-in 也不是第三方 server-side bot 可用的 API OAuth。
-- **授權策略**：目前維持 MIT，不立即轉 FSL-1.1-MIT；直接併入 FSL / GPL / 未授權專案原始碼前先看 [`docs/ROADMAP.md`](docs/ROADMAP.md)。
-- 不要把 OpenAI 換成其他預設供應商、不要引入 Anthropic SDK、不要動搖「使用者自架、自備金鑰」的本質。
+- **LINE-first**：不要為了抽象化而改造成多頻道平台。
+- **OpenAI-default**：未有明確產品決策前，不替換預設 AI provider，也不直接引入其他 provider SDK。
+- **Self-hosted / BYO keys**：憑證、模型、webhook、資料庫與第三方服務設定一律走環境變數，不寫死個人值。
+- 不提交 API key、token、`.env`、LINE secret、OpenAI／SerpAPI／Google／Supabase 憑證或任何私密資料。
+- 不移除上游 MIT／attribution；來源與第三方聲明以 [`NOTICE.md`](NOTICE.md) 為準。
+- 不宣稱 LINE、OpenAI、Google、Supabase、Vercel 或其他服務官方背書。
+- 保留 durable queue、webhook idempotency、delivery checkpoint、migration preflight 與 fail-closed 原則；不要為了簡化流程退回 process-memory 或 fail-open runtime。
+- 不新增不必要的原始 LINE user id、名稱或長期對話內容保存。既有 HMAC identifier、加密 job payload 與結構化持久狀態的邊界不可在未評估下放寬。
+- Google Calendar／Tasks 的支援範圍以既有 contract 為準；不要把尚未支援的 all-day／recurrence inbound、非 primary 匯入或 Tasks due reclaim 當成已完成能力。
 
-## 硬性邊界
+## 架構地圖
 
-- 不提交 API key、token、`.env` / `.env.*`、LINE channel secret、OpenAI/SerpAPI 金鑰或任何私密憑證。
-- 不移除 MIT 授權與對 `memochou1993/gpt-ai-assistant` 的 attribution；見 [`NOTICE.md`](NOTICE.md)。
-- 不把預設模型／金鑰／webhook 路徑寫死成特定人的值；一律走環境變數（見 `config/index.js` 與 `.env.example`）。
-- 不宣稱本專案為 LINE、OpenAI 或任何服務官方或背書。
-- 不在未確認方向前，替換 AI 供應商或大改指令協定。
-- 不把使用者對話內容、LINE user id 等個資落地或外傳。
-
-## 架構速覽
-
-```text
-LINE 使用者 ──▶ LINE Messaging API ──▶ webhook（Vercel serverless / 本機 Express）
-                                              │
-                                     api/index.js（入口）
-                                              │
-                                     app/（事件 → context → handlers/commands）
-                                              │
-                        ┌─────────────────────┼─────────────────────┐
-                        ▼                      ▼                     ▼
-                   OpenAI API       SerpAPI       Supabase / Google Calendar
-              （completion/image/vision）              │
-                                                       ▼
-                                                   LINE reply
-```
-
-- `api/index.js`：serverless / server 入口，掛 webhook。
-- `app/`：事件處理核心——`app.js` 收 LINE events，`context.js` 建 context，`handlers/` 與 `commands/` 實作各指令（talk / draw / search / sum / analyze / translate / continue / retry / forget / report / version / deploy / doc…）。
-- `config/index.js`：所有環境變數的單一讀取點（凍結物件）。
-- `utils/`、`services/`（OpenAI / LINE / SerpAPI / Google Calendar / queue）、`repositories/`（Supabase data access）、`app/models/`（bot / event / context 模型）。
+- `api/`：HTTP / Vercel serverless 入口、webhook
+- `app/`：LINE event → context → handlers / commands
+- `services/`：OpenAI、LINE、Google、queue、reminders、weather、search 等服務
+- `repositories/`：Supabase data access
+- `db/`：migrations / rollbacks
+- `contracts/`：跨服務契約與能力邊界
+- `config/index.js`：環境變數單一讀取點
+- `tests/`：Jest 回歸測試
+- `tools/`：依賴 freshness / Dependabot policy 等維護工具
 
 ## 開發原則
 
-- 改行為前先讀 `config/index.js`，確認相關開關與預設值。
-- 新增指令依現有 `handlers/` + `commands/` 模式擴充，別另立平行架構。
-- 動到金鑰、webhook、部署流程時，同步更新 `.env.example` 與 [`docs/DEVELOPMENT.md`](docs/DEVELOPMENT.md)。
-- 使用繁體中文回覆與撰寫維護文件；程式碼、變數、commit message 維持英文。
-- 面向使用者的說明改 README（中文版為主）；架構與部署細節進 `docs/DEVELOPMENT.md`；重要取捨進 `docs/DECISIONS.md`。
+- 一般變更走 **branch → PR → CI → merge**，不要直接在 `main` 上堆工作。
+- 改行為前先讀 `config/index.js` 與相關 service / repository / contract，確認 feature flag、預設值與 durable 路徑。
+- 新增 LINE 指令時沿用既有 `handlers/` + `commands/` 模式；不要另建平行 command framework。
+- 會造成付費 API 呼叫的流程要維持「運算完成」與「LINE 送達」分離，重試不得無意重跑付費工作。
+- 資料寫入、queue claim、Google sync、reminder lifecycle 等一致性修改要優先補 repository / service 級回歸測試。
+- 修改 migration 時，保留 forward migration、preflight 與 rollback 的一致性，不改寫已發布 migration 的歷史語意。
+- 不為了「更完整」主動增加新的 governance workflow；目前 CI、CodeQL、Dependabot 與 dependency-freshness 已足夠。
+- 純文件／維護規則整理不需要機械式 bump 版本。
 
-## 驗證方向
+## 文件 source of truth
 
-改動後至少確認：
+### 使用者文件：`SanHsien/gpt-ai-assistant-docs`
+
+獨立文件 repo 是以下內容的權威來源：
+
+- 安裝
+- 部署
+- 環境變數與第三方服務設定
+- Google OAuth 操作
+- 使用方式
+- 疑難排解
+
+本 repo 的 README 只做產品入口與必要快速開始，不複製完整使用者手冊。
+
+### 本 app repo
+
+本 repo 是以下內容的權威來源：
+
+- runtime 行為與程式契約
+- API / provider contract
+- DB migrations / rollbacks
+- 架構與開發流程
+- 技術決策
+- release implementation / evidence
+
+文件分工：
+
+- `README.md` / `README.en.md`：產品入口、能力與必要安全／部署摘要
+- `docs/DEVELOPMENT.md`：runtime 架構、開發、部署實作與驗證
+- `docs/ROADMAP.md`：產品範圍、Google contract、未來與明確不做
+- `docs/DECISIONS.md`：耐久性技術／產品決策
+- `REVIEW.md`：最新 evidence-based 覆核與未驗證項
+- `CHANGELOG.md`：正式版本歷史
+- `NOTICE.md`：來源、授權與第三方聲明
+
+只更新**真正受此次變更影響**的文件；不要要求每次 commit 都同步 README、ROADMAP、REVIEW、CHANGELOG、DECISIONS 與文件站全套。
+
+### REVIEW.md 規則
+
+`REVIEW.md` 是最新覆核快照，不是每個 bug 的強制流水帳。
+
+- 若此次工作直接修復 `REVIEW.md` 已追蹤的問題，更新對應狀態與證據。
+- 若新發現的問題會實質改變目前風險／驗證結論，更新 `REVIEW.md`。
+- 一般 bug fix 若已有測試、PR 與 CHANGELOG／commit evidence，**不因規則本身而新增 REVIEW bookkeeping**。
+
+## 驗證
+
+一般程式變更至少執行：
 
 ```bash
 npm ci
-npx eslint .      # ESLint flat config；無 npm script，直接跑
-npm test          # jest
+npx eslint .
+npm run test:module-load
+npm test
 ```
 
-必要時本機起服務手動打 webhook：
+CI 另外會：
 
-```bash
-npm run dev       # nodemon api/index.js
-```
+- 建立 production Docker image
+- 啟動容器
+- 驗證 `/health/live`
+- 驗證 image healthcheck
 
-不接受「應該可以」——面向行為的改動要用 lint + test 或本機實跑佐證。
+依變更範圍追加：
 
-需要 AI 操作 LINE Windows app、Google OAuth、Supabase Dashboard 或 Production smoke test 時，開始前必須先讀完 [`docs/DEVELOPMENT.md`](docs/DEVELOPMENT.md) 的「AI 操作 LINE PC 的正式驗收流程」。沿用已登入的 LINE／Chrome 狀態，控制 handle 失效時自行重新列舉與恢復；Google 登入交接完成後要主動續做 LINE、Calendar、Supabase、Vercel 與精準清理閉環，不可把中途工具限制當成產品限制或過早停止。
+- migration / durable runtime：`npm run db:migrate`、`npm run db:preflight` 與對應 migration/repository tests
+- dependency policy：`npm run check:dependencies` / `npm run check:dependabot-policy`
+- Production LINE / Google / Supabase / Vercel 實機流程：先讀 `docs/DEVELOPMENT.md` 的正式驗收 runbook，且未完成的外部驗證要明確標示，不得用「應該可用」代替證據
 
-## 文件入口
+## 完成條件
 
-- [`README.md`](README.md) / [`README.en.md`](README.en.md)：使用者入口、功能與部署（中文為主）。
-- [`REVIEW.md`](REVIEW.md)：最新一次 evidence-based 專案覆核、release gate 與未驗證項（只留最新版）。**修 bug 必回註（適用所有 AI agent：Claude、Codex 等，維護者 2026-07-19 指示）**：每修復 REVIEW.md 列出的問題，須回到對應項目標註修復 commit hash 與日期；修復過程中額外發現並修掉的 bug 也要補註。REVIEW 維持 latest-only，但修復狀態必須跟上現況。
-- [`docs/ROADMAP.md`](docs/ROADMAP.md)：產品階段、Phase 狀態、模型／API、參考架構與授權邊界。
-- [`docs/DEVELOPMENT.md`](docs/DEVELOPMENT.md)：架構、本機指令、環境變數、部署（Vercel 優先）。
-- [`docs/DECISIONS.md`](docs/DECISIONS.md)：決策紀錄。
-- [`NOTICE.md`](NOTICE.md)：上游來源、MIT 授權與第三方聲明。
-- [`CHANGELOG.md`](CHANGELOG.md)：版本變更（沿用上游格式）。
+提交前確認：
+
+1. 沒有突破 LINE-first、OpenAI-default、自架／BYO keys 與 durable runtime 邊界。
+2. 相關測試、lint、module-load 或 runtime preflight 已按變更範圍通過。
+3. 沒有秘密、個資、production token 或測試殘留進 repo。
+4. 只更新必要文件；使用者部署／操作細節若有變更，同步到 `gpt-ai-assistant-docs` 的權威頁面。
+5. PR 清楚列出使用者可見影響、資料／同步風險、驗證結果與未驗證範圍。

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,13 +1,9 @@
 # CLAUDE.md
 
-Claude Code 在本專案工作時的指引。**專案定位、維護方向、硬性邊界、架構速覽、常用位置與驗證方向的唯一真相源是 [`AGENTS.md`](AGENTS.md)**——先讀它，本檔只補 Claude 專屬要點，不重複規則。
+Claude Code 在本專案工作時，先讀 [`AGENTS.md`](AGENTS.md)。**產品邊界、架構、文件分工與驗證規則都以 `AGENTS.md` 為準**；本檔只補 Claude 專屬工作方式，不複製專案規則。
 
-## 回覆要求
-
-- 使用繁體中文，先講修改、驗證、剩餘事項。
-- 不要把簡單任務寫成冗長架構分析。
-- 動到金鑰／webhook／部署流程時，同步更新 `.env.example` 與 [`docs/DEVELOPMENT.md`](docs/DEVELOPMENT.md)。
-
-## 文件同步
-
-新增／改動功能後，同步對應文件（各主題單一真相源）：使用者說明 [`README.md`](README.md)／[`README.en.md`](README.en.md)、最新覆核與未驗證項 [`REVIEW.md`](REVIEW.md)、變更 [`CHANGELOG.md`](CHANGELOG.md)、Phase 狀態與範疇 [`docs/ROADMAP.md`](docs/ROADMAP.md)、決策理由 [`docs/DECISIONS.md`](docs/DECISIONS.md)、授權與參考專案 [`NOTICE.md`](NOTICE.md)。文件站（另一 repo `gpt-ai-assistant-docs`，中英）在版本／功能敘述變動時一併更新。
+- 以繁體中文回報修改、驗證與剩餘風險。
+- 不把簡單任務擴寫成大型重構或文件工程。
+- 涉及金鑰、webhook、durable queue、migration、Google sync 或 Production smoke 時，先讀相關實作與 `docs/DEVELOPMENT.md`，不要從 README 推測完整操作。
+- 使用者部署／設定／操作／疑難排解的權威文件在 `SanHsien/gpt-ai-assistant-docs`；app repo 只更新真正受影響的 runtime／架構／決策文件。
+- 未完成的 LINE／Google／Supabase／Vercel 實機驗證要明確標示，不能以工具限制或「應該可用」代替產品證據。

--- a/README.en.md
+++ b/README.en.md
@@ -1,150 +1,192 @@
 # GPT AI Assistant
 
-[![Release](https://img.shields.io/github/v/release/SanHsien/gpt-ai-assistant?sort=semver)](https://github.com/SanHsien/gpt-ai-assistant/releases)
+[![Release](https://img.shields.io/github/v/release/SanHsien/gpt-ai-assistant?sort=semver)](https://github.com/SanHsien/gpt-ai-assistant/releases/latest)
 [![CI](https://github.com/SanHsien/gpt-ai-assistant/actions/workflows/ci.yml/badge.svg)](https://github.com/SanHsien/gpt-ai-assistant/actions/workflows/ci.yml)
 [![CodeQL](https://github.com/SanHsien/gpt-ai-assistant/actions/workflows/codeql.yml/badge.svg)](https://github.com/SanHsien/gpt-ai-assistant/actions/workflows/codeql.yml)
-[![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
-[![Node.js 24](https://img.shields.io/badge/node-24-339933.svg)](package.json)
-[![Platform: LINE](https://img.shields.io/badge/platform-LINE-00B900.svg)](https://developers.line.biz/)
-[![Powered by OpenAI](https://img.shields.io/badge/AI-OpenAI-412991.svg)](https://platform.openai.com/)
-[![Tests: Jest](https://img.shields.io/badge/tests-jest-blueviolet.svg)](tests)
-[![Deploy: Vercel](https://img.shields.io/badge/deploy-Vercel-000000.svg)](https://vercel.com/)
+[![Node.js 24](https://img.shields.io/badge/Node.js-24-339933.svg)](package.json)
+[![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
 
-[繁體中文](README.md) | [English](README.en.md)
+[繁體中文](README.md) · [English](README.en.md) · [Documentation](https://sanhsien.github.io/gpt-ai-assistant-docs/en/) · [Latest Release](https://github.com/SanHsien/gpt-ai-assistant/releases/latest)
 
-`GPT AI Assistant` is a chatbot that connects the **OpenAI API** with the **LINE Messaging API**. Once deployed, you can chat with your own AI assistant right inside the LINE mobile app — conversation, image generation, image understanding, and web search, all in the LINE chat.
+**GPT AI Assistant** is a self-hosted **personal AI assistant for LINE**. Deploy it with your own LINE, OpenAI, and Supabase configuration, then chat, send voice or images, search the web, manage events and tasks, receive reminders, and check weather without leaving LINE.
 
-This repository originated from [`memochou1993/gpt-ai-assistant`](https://github.com/memochou1993/gpt-ai-assistant) (MIT) and is now independently maintained by SanHsien. The Traditional Chinese [`README.md`](README.md) is the primary document.
+It is more than a chat wrapper. LINE is the user interface, while a **durable queue and persistent assistant state** provide the reliability layer behind the bot. Paid AI work and LINE delivery use separate checkpoints, events and tasks survive serverless restarts, and Google Calendar / Tasks can be connected when needed.
 
-## What it is
+> **For installation, environment variables, Google OAuth, user workflows, and troubleshooting, use the [documentation site](https://sanhsien.github.io/gpt-ai-assistant-docs/en/).** The `docs/` directory in this repository focuses on runtime behavior, architecture, data contracts, migrations, technical decisions, and release implementation.
 
-- **Native LINE experience** — no separate app; talk to your assistant in LINE.
-- **Self-hosted, bring-your-own keys** — deploy with your own OpenAI and LINE channel credentials; data and billing stay yours.
-- **Serverless deployment** — Vercel-first, one-click deploy (local Node or Docker also supported).
-- **Command-based features** — beyond chat: image generation, vision, search, translation, scheduling, and summarize/analyze commands.
+## Who it is for
 
-## Features
+- People who want their own AI assistant **inside LINE**, rather than another chat application.
+- Users comfortable self-hosting and bringing their own OpenAI, LINE, and Supabase credentials and billing.
+- People who need more than chat: **events, tasks, reminders, search, voice, images, and weather**.
+- Developers who care about webhook idempotency, durable jobs, retries, and explicit data boundaries in serverless environments.
 
-| Category | What it does |
-|------|----------|
-| 💬 Chat | Continuous conversation (`talk`); `continue`, `retry`, `forget` |
-| 🎙️ Voice | Send a LINE voice message, or attach an mp3/mp4/mpeg/mpga/m4a/wav/webm file from Windows/macOS; OpenAI speech-to-text (default `gpt-4o-mini-transcribe`) handles it as normal input, including **voice-created events**. The confirmation card echoes "🎤 Heard: ..."; `TRANSCRIPTION_MAX_BYTES` defaults to 25 MiB |
-| 🎨 Draw | Generate images from a text prompt (`draw`, default GPT Image 2) |
-| 👁️ Vision | Send an image for the AI to understand and describe (default `gpt-4o`) |
-| 🔍 Search | Web search via SerpAPI (`search`) with a "📎 Sources" list (title/source/date/link; shown only, never fed into the prompt) |
-| 🗓️ Schedule and reminders | Create an event (text or voice) with `Schedule ...` or a date-led statement such as `7/20 3 PM dental follow-up`. Ambiguous time prompts one focused question; event editing, overlap warnings, one-day-ahead and at-time reminders, completion, deletion, and authorized Google Calendar updates are supported. **Inbound sync** (`ENABLE_GOOGLE_CALENDAR_INBOUND`) also imports existing future one-off timed events from the primary calendar even when they were not created by the bot, then reschedules or cancels LINE reminders after Google-side changes. Reminders honor `Quiet hours 22-8` and `Pause reminders`/`Resume reminders` |
-| ✅ Tasks | An assistant todo list stored independently in the Supabase `tasks` table. With `ENABLE_GOOGLE_TASKS`, create/complete/reopen/delete sync to Google Tasks (shared Calendar OAuth); with `ENABLE_GOOGLE_TASKS_INBOUND`, Google-side completion/reopen, deletion, title, and notes are reclaimed back (due is not reclaimed — the precise deadline stays authoritative locally). Tasks with a due time send LINE reminders one day ahead and at the deadline by default; lifecycle changes cancel or reschedule them. `Add task urgent submit report tomorrow #work` parses due date, priority, and `#tags`; use `My tasks` with `today/tomorrow/this week/next week/overdue/completed/#tag` filters, pagination, and one-tap complete, reopen, or delete (`ENABLE_TASKS`, off by default, needs `DATABASE_URL`) |
+The production acceptance baseline is currently **Traditional Chinese (`zh_TW`) + LINE + OpenAI**. English and Japanese interfaces can run, but natural-language date parsing, weather formatting, and some intent recognition remain Chinese-oriented and should be treated as experimental localization.
 
-Task date aliases are resolved in the user's timezone. A broad `this week` deadline without a weekday is fixed to Sunday at 09:00; `next week` uses the following Sunday, so the model cannot pick an arbitrary day.
-| 🌤️ Weather | Current conditions and forecasts (`Weather Taipei`); Taiwan place shorthand completion and same-name disambiguation, plus daily subscription push (`Daily weather Taipei 8`, `ENABLE_WEATHER_PUSH`). Data from Open-Meteo (free, no API key) with short-term caching (`ENABLE_WEATHER`, off by default) |
-| 🌐 Translate | Translate to English / Japanese (`translate`) |
-| 🧠 Summarize / Analyze | `sum` (advise, comfort, encourage…) and `analyze` (literary, mathematical, philosophical, psychological…) |
-| ⚙️ System | `activate` / `deactivate`, `version`, `report`, `deploy` (self-redeploy), `doc` |
+## Core capabilities
 
-> Send `Command` to receive a grouped list of commands and examples generated from the features enabled on that deployment. The docs site provides the extended feature reference.
+| Area | What it does |
+| --- | --- |
+| AI chat | Continuous conversation, continue, retry, and forget; models are configurable through environment variables |
+| Voice and images | LINE voice/common audio transcription, image understanding, and GPT Image generation |
+| Search and URLs | SerpAPI web search; optional SSRF-safe URL summarization; search replies include source links |
+| Events | Natural-language create/edit/complete/delete, conflict warnings, recurring schedules, and LINE reminders |
+| Google Calendar | Authorized outbound CRUD plus safe-scope inbound sync for timed non-recurring events on the primary calendar |
+| Tasks | Supabase-backed todos with due dates, priority, tags, filters, complete/reopen/delete, and deadline reminders |
+| Google Tasks | Optional outbound/inbound state synchronization; precise due-time authority remains local |
+| Weather | Open-Meteo current conditions, forecasts, and optional daily weather push without another API key |
+| LINE UX | Feature-aware Quick Replies, confirmation cards, postbacks, quiet hours, and pause/resume reminders |
 
-General replies attach up to 13 feature-aware LINE quick replies: `Schedule`, `My events`, `Add task`, `My tasks`, `Weather`, `Daily weather`, `Search`, `Draw`, `Link Google Calendar`, `Pause reminders`, `Resume reminders`, `Forget`, and `Command`. LINE renders quick replies as a single horizontal strip; the bot can't force a second row. Forks that want a persistent two-row mobile launcher can optionally configure the recommended 3×2 LINE Official Account rich menu described in [`docs/DEVELOPMENT.md`](docs/DEVELOPMENT.md#line-quick-replies-and-optional-rich-menu).
+Feature flags can disable higher-cost or optional capabilities such as image generation, transcription, vision, search, tasks, weather, and Google integrations. See the [documentation](https://sanhsien.github.io/gpt-ai-assistant-docs/en/) and [`.env.example`](.env.example) for the authoritative configuration list.
 
-`APP_LANG` accepts `zh_TW`, `zh`, `zh_CN`, `en`, and `ja`. Only `zh_TW` is fully accepted and production-supported today. `zh` and `zh_CN` currently reuse Traditional Chinese strings rather than a Simplified Chinese pack. English and Japanese start successfully and cover the main commands and Google OAuth pages, but weather formatting and natural-language date/intent parsing remain Chinese-oriented; treat them as experimental rather than complete localized deployments.
+## What using it feels like
 
-Google Calendar synchronization retries automatically up to three attempts in the background. The bot announces success only after Google accepts the event. A final failure offers **Retry sync**, **Not now**, and **Delete event**. Not now keeps the Supabase event and stops prompting; use `Failed syncs` later, then `Retry sync <ID>` or `Delete event <ID>`. Nothing is deleted without an explicit delete action.
+Inside LINE, you can send natural requests such as:
 
-Schedule shortcuts use LINE postbacks. The conversation shows natural labels such as **Confirm event** or **Complete event 2**; list actions include the current row number, while confirmation tokens, Supabase UUIDs, and Google event ids stay in hidden postback data. Text commands containing `<ID>` remain available only as a manual troubleshooting fallback.
+```text
+Tomorrow at 3 PM dental follow-up
+Add task urgent submit report tomorrow #work
+Weather Taipei
+Search for this week's important OpenAI news
+```
 
-An incomplete event remains a durable structured draft, never raw conversation text. The next natural-language answer continues it across serverless instances. Date-only statements become all-day events; vague periods such as "tomorrow afternoon" prompt for an exact time. `Edit event` lists editable local mappings and confirms the revised draft before applying it. Optimistic version checks reject stale overwrites, while overlap detection warns and leaves the final choice to the user.
->
-> Each capability can be turned off individually for cost control (all on by default): `ENABLE_IMAGE_GENERATION`, `ENABLE_TRANSCRIPTION`, `ENABLE_VISION`, `ENABLE_SEARCH`.
+When an event is incomplete, the assistant asks for the missing detail before writing anything. A complete draft must be confirmed first. If Google synchronization later fails, the local record is retained and the bot offers retry, defer, or delete instead of silently discarding state.
 
-## Quick start (Vercel-first)
+LINE voice messages and supported audio attachments are transcribed and then enter the same input pipeline as text. Event confirmation echoes the transcript so users can distinguish a transcription mistake from a scheduling-parsing mistake.
 
-1. **Get your keys** — OpenAI, LINE, SerpAPI (or disable search), plus a Supabase pooler URL, CA, and data-encryption key.
-2. **Deploy to Vercel** — import this repo and set all required runtime variables as Production Sensitive values.
-3. **Migrate and preflight** — run `npm run db:migrate` through `0020`, then `npm run db:preflight`.
-4. **Set the LINE webhook** — point your LINE channel's Webhook URL to `{your-url}/webhook` and enable it.
-5. **Start chatting** — add the LINE official account as a friend and send a message.
+## Reliability and data boundaries
 
-Version 6.0 requires Supabase Postgres with migrations `0001`–`0020`; there is no synchronous or Vercel-environment storage fallback. Health checks and webhooks fail closed when durable configuration, the database, or migrations are unavailable. Reminders also require Supabase Cron to call the protected worker endpoint every minute. Enable tasks and weather with `ENABLE_TASKS` and `ENABLE_WEATHER`. Google Calendar and Tasks additionally require a Web OAuth client, Vercel Production Sensitive environment variables, and both **Google Calendar API** and **Google Tasks API** enabled in the same Google Cloud project; granting the Tasks OAuth scope does not enable its API. Follow the deployment checklist in [`docs/DEVELOPMENT.md`](docs/DEVELOPMENT.md#完整上線順序): enable APIs, apply migrations, and configure Cron before enabling flags and redeploying. After enabling `ENABLE_GOOGLE_TASKS`, send `Connect Google Calendar` again to grant the Tasks scope and backfill existing unsynced tasks. If synchronization previously failed because the API was disabled, enable it and reconnect; `rc.5` safely revives the same dead sync job instead of creating another task.
+The engineering focus is not only answer quality. The runtime is designed to avoid duplicate paid work, duplicate replies, and lost state in serverless execution:
 
-See [`.env.example`](.env.example) for the full variable list and `config/index.js` for defaults.
+- Webhooks pass durable preflight and idempotent persistence before processing; missing required configuration, database failures, or stale migrations fail closed so LINE can redeliver.
+- **AI completed** and **LINE delivered** are separate checkpoints. Delivery retries resend saved output instead of rerunning paid AI work.
+- Durable job payloads are encrypted. User/group state uses deployment-scoped HMAC identifiers rather than storing raw LINE user ids or names.
+- General conversation text is not treated as a permanent profile database; persistent storage is reserved for structured assistant state, jobs, and necessary operational records.
+- Google Calendar / Tasks are used only after the user completes OAuth authorization for the relevant scopes.
+
+See [`docs/DEVELOPMENT.md`](docs/DEVELOPMENT.md), [`docs/DECISIONS.md`](docs/DECISIONS.md), and [`REVIEW.md`](REVIEW.md) for the full runtime, security, and evidence details.
+
+## Google integration boundaries
+
+Calendar currently supports outbound management of bot-managed events plus safe-scope inbound synchronization for **future, timed, non-recurring** events on the primary calendar. These remain intentionally outside the complete inbound contract:
+
+- all-day Calendar events
+- recurring series / exceptions
+- non-primary calendar imports
+- Google Tasks due-date reclamation
+
+These are explicit product boundaries, not failures of the normal LINE event/task workflows. See [`docs/ROADMAP.md`](docs/ROADMAP.md) for the detailed contract.
+
+## Quick start
+
+### 1. Prepare services
+
+A basic deployment needs:
+
+- a LINE Messaging API channel
+- an OpenAI API key
+- Supabase Postgres
+- Node.js 24
+- Vercel (recommended), or another Node/Docker-capable host
+
+Search, Google Calendar / Tasks, and image Blob delivery require additional configuration.
+
+### 2. Install and preflight
+
+```bash
+git clone https://github.com/SanHsien/gpt-ai-assistant.git
+cd gpt-ai-assistant
+npm ci
+cp .env.example .env
+npm run db:migrate
+npm run db:preflight
+```
+
+### 3. Deploy and configure the LINE webhook
+
+After deployment, point the LINE channel Webhook URL to:
+
+```text
+https://YOUR_HOST/webhook
+```
+
+Before production use, verify migrations, Cron, Production Sensitive environment values, and any APIs/OAuth required by enabled features. **Do not infer the full deployment sequence from this README**; follow the [complete deployment documentation](https://sanhsien.github.io/gpt-ai-assistant-docs/en/).
 
 ## Local development
 
-Node.js 24 is required.
-
 ```bash
 npm ci
-cp .env.example .env    # fill in your keys
-npm run dev             # nodemon Express server
-npx eslint .            # ESLint flat config
-npm test                # jest
+cp .env.example .env
+npm run dev
+npx eslint .
+npm run test:module-load
+npm test
 ```
 
-The LINE webhook needs a publicly reachable HTTPS URL — use ngrok / cloudflared to expose your local port. Architecture and deployment details are in [`docs/DEVELOPMENT.md`](docs/DEVELOPMENT.md).
+The LINE webhook needs a publicly reachable HTTPS endpoint; use ngrok, cloudflared, or a similar tunnel for local testing.
 
-## Direction & roadmap
+CI also builds the production Docker image, starts the container, and validates `/health/live` plus the image healthcheck.
 
-This project keeps **OpenAI + LINE, self-hosting, and user-supplied API keys** while evolving in phases into a personal assistant. It will not be rewritten wholesale or switch its default provider. See [`docs/ROADMAP.md`](docs/ROADMAP.md) for phases, data models, API/model choices, reference architecture, and licensing boundaries.
+## Architecture at a glance
 
-### Done
+```text
+LINE
+  │ webhook
+  ▼
+api/index.js
+  │ preflight / durable enqueue / idempotency
+  ▼
+Supabase-backed jobs
+  │
+  ├── OpenAI ── chat / transcription / vision / image
+  ├── SerpAPI ── search
+  ├── Google ── Calendar / Tasks
+  └── Open-Meteo ── weather
+  │
+  ▼
+LINE delivery checkpoint
+```
 
-- **Security hardening**: webhook fails closed when `LINE_CHANNEL_SECRET` is missing, `.env.example` defaults `APP_DEBUG=false`, CodeQL scanning + Dependabot added, dependency vulnerabilities resolved.
-- **6 bug fixes**: group `forget` not clearing history, `search` crash on no results, `version` command taking down the batch, health route hanging, `stop` sequences never sent, audio temp-file leak.
-- **Durable source state**: user/group activation uses only deployment-scoped HMAC keys in Postgres with atomic limits; raw LINE IDs and names are not persisted.
-- **Default model upgrades**: chat `gpt-4o-mini`, image `gpt-image-2` (`low` quality), transcription `gpt-4o-mini-transcribe` (all env-overridable).
-- **Capability feature flags**: `ENABLE_IMAGE_GENERATION` / `ENABLE_TRANSCRIPTION` / `ENABLE_VISION` / `ENABLE_SEARCH` for cost control.
-- **Conversation TTL**: `APP_MAX_PROMPT_AGE` expires idle conversation context (disabled by default; set seconds to enable).
-- **CI + badges**: GitHub Actions runs eslint + jest on every push; README shows live CI / CodeQL status badges.
-- **Group reply policy**: `GROUP_REPLY_REQUIRES_MENTION` makes groups require a mention before replying, reducing noise (off by default).
-- **LINE delivery checkpoint**: failed replies resend only the saved result, never rerun paid AI work or silently fall back to quota-counted Push API calls.
-- **URL summary**: `ENABLE_URL_SUMMARY` (off by default) fetches a URL in the message via an SSRF-safe fetch and uses the page as summary context; residual risks in [`docs/DEVELOPMENT.md`](docs/DEVELOPMENT.md).
-- **GPT Image support**: `gpt-image-2` is the default; base64 images are uploaded to private Vercel Blob and shared with LINE through a temporary signed URL. The model and quality remain configurable. Setup in [`docs/DEVELOPMENT.md`](docs/DEVELOPMENT.md).
-- **Webhook deduplication**: LINE redeliveries and repeated `webhookEventId` values are processed only once, preventing duplicate paid API calls and replies.
-- **Durable foundation (Phase 0)**: Supabase Postgres, atomic webhook idempotency, lease-fenced jobs, encrypted payloads, and HMAC-derived user keys. Version 6.0 always queues durably; missing IDs, database failures, or stale migrations reject the ACK so LINE can redeliver.
-- **Events and reminders**: one sentence becomes a JSON-Schema-validated draft; explicit dates and local wall-clock times are resolved deterministically, while incomplete details continue through a durable structured clarification. Recurring phrases such as `Every day at 22:40 routine check` enter the schedule flow directly and show the recurrence rule before confirmation. Create and edit use token-bound confirmation, row locking, optimistic versions, and overlap warnings. `Connect Google Calendar` starts OAuth without invoking general chat; create and bot-originated updates sync through idempotent durable jobs, while list, complete, and delete call Google Calendar.
-- **Durable checkpoints**: "AI finished" and "LINE delivered" are separate checkpoints, giving at-most-once AI work with retryable delivery. Delivery retries do not rerun the paid AI phase or duplicate a successful LINE reply.
+Main code areas:
 
-### 6.x stable releases
+- `api/`: HTTP / serverless entry points
+- `app/`: LINE events, context, handlers, and commands
+- `services/`: AI, LINE, Google, queue, reminders, and integrations
+- `repositories/`: Supabase data access
+- `db/`: migrations and rollbacks
+- `config/index.js`: single environment-variable read point
+- `tests/`: Jest regression tests
 
-- **`6.1.0` (current)** changes the default lead reminder to **one day ahead** while keeping the at-start reminder; the Calendar inbound v3 baseline imports existing future, non-recurring, timed Google-origin events from the primary calendar (including ones the bot did not create), and later incremental creates/edits/deletes schedule, reschedule, or cancel LINE reminders. **Tasks with a due date** get the same lead and due reminders. It also adds the Dependabot classification, guarded merge, and monthly dependency-freshness maintenance loop.
-- **`6.0.1`** fixes event deletion removing only the `events` row without cancelling pending reminders; LINE and Google inbound deletions now share one atomic SQL statement.
-- **`6.0.0`** completes the durable-only runtime, Google Calendar/Tasks contract, reminders, recurrence, search, weather, and desktop audio path, with centralized LINE/Supabase/Google acceptance complete. Spoken Chinese schedule-prefix homophones are normalized while the raw transcript remains visible for confirmation.
-- **Google contract limits**: Calendar outbound CRUD, mapped timed non-recurring inbound, and importing future timed non-recurring Google-origin events from the primary calendar are supported. The first baseline imports existing supported events; later edits and deletions reschedule or cancel LINE reminders. Calendar all-day events, recurring series/exceptions, non-primary imports, and Tasks due-date inbound remain explicitly unsupported.
-- **Further model/API upgrades** — first pass done; new models must be re-verified against official documentation before use, see [`docs/ROADMAP.md`](docs/ROADMAP.md).
-- **Adopt selected fermi architecture lessons** — rebuild reliability, persistence, observability in phases; do not merge fermi source code directly.
-- **A Claude-based assistant** — possible future version, TBD.
+## Documentation ownership
 
-### Excluded directions
+### User documentation
 
-- **OpenAI / ChatGPT subscription OAuth instead of API keys** — OpenAI currently bills and manages ChatGPT subscriptions separately from API usage; this repo should not be designed as a third-party LINE bot that consumes a user's ChatGPT subscription quota.
-- **CalDAV / Apple / ICS interop (former Phase 5B)** — Google Calendar bidirectional sync already covers the single-Google-account personal use case; cross-protocol interop costs outweigh the benefit.
-- **Event sharing and group collaboration (former Phase 8)** — stays a single-user personal assistant; no share links or group permission model.
-- **Multi-channel adapters (former Phase 9)** — LINE is the sole optimized channel.
-- **Search topic-tracking push and multi-source cross-referencing (former Phase 7 items)** — search stays user-initiated ask-and-answer with source links only.
-- **Image-to-event capture (former Phase 4 item)** — vision confidence/multi-event complexity is high; images stay for vision chat. (**Voice-created events are implemented.**)
-- **Batch creation of multiple events at once (former Phase 1 item)** — needs a multi-draft, per-item/all confirmation state machine; low value for single-user use, where one-by-one entry or recurring events already cover most needs.
+- [Documentation site](https://sanhsien.github.io/gpt-ai-assistant-docs/en/)
+- [Traditional Chinese docs](https://sanhsien.github.io/gpt-ai-assistant-docs/)
+- [`SanHsien/gpt-ai-assistant-docs`](https://github.com/SanHsien/gpt-ai-assistant-docs): source of truth for installation, deployment, configuration, usage, and troubleshooting
 
-The last six were decided on 2026-07-17; see [`docs/ROADMAP.md`](docs/ROADMAP.md).
+### Maintainer documentation in this repo
 
-See [`docs/DECISIONS.md`](docs/DECISIONS.md) and [`docs/ROADMAP.md`](docs/ROADMAP.md) for phase status.
+- [`docs/DEVELOPMENT.md`](docs/DEVELOPMENT.md): runtime architecture, development, deployment implementation, and validation
+- [`docs/ROADMAP.md`](docs/ROADMAP.md): product boundaries, data/Google contracts, and future direction
+- [`docs/DECISIONS.md`](docs/DECISIONS.md): technical and product decisions
+- [`REVIEW.md`](REVIEW.md): latest evidence-based project review and unverified items
+- [`CHANGELOG.md`](CHANGELOG.md): version history
+- [`NOTICE.md`](NOTICE.md): provenance, attribution, and third-party notices
 
-## Docs
+## Product direction
 
-- Docs site (Chinese): <https://sanhsien.github.io/gpt-ai-assistant-docs/>
-- Docs site (English): <https://sanhsien.github.io/gpt-ai-assistant-docs/en/>
-- Maintenance docs: [roadmap and technical evaluation](docs/ROADMAP.md), [development and deployment](docs/DEVELOPMENT.md), and [decision log](docs/DECISIONS.md)
+GPT AI Assistant keeps these core constraints:
 
-> The docs site originated from [`memochou1993/gpt-ai-assistant-docs`](https://github.com/memochou1993/gpt-ai-assistant-docs) (VuePress), is now independently maintained, and is published via GitHub Pages. Upstream original: <https://memochou1993.github.io/gpt-ai-assistant-docs/>.
+- **LINE remains the sole primary user interface** rather than becoming a multi-channel platform.
+- **OpenAI remains the default AI provider**, using user-supplied API keys.
+- **Self-hosting and a verifiable durable runtime** take priority over adding more chat gimmicks.
+- Google Calendar / Tasks remain personal-assistant integrations rather than expanding into multi-user collaboration or enterprise workflow software.
 
-## Other reference projects
+Completed work, excluded directions, and future planning live in [`docs/ROADMAP.md`](docs/ROADMAP.md); the README intentionally does not maintain a second parallel roadmap.
 
-This project references a few services and open-source projects for concepts, specs, or deployment flows only (official LINE/OpenAI docs, other Traditional-Chinese LINE bots, fermi, Toki, etc.) and includes **none of their source code**; GPL / FSL / unlicensed projects are not merged into this MIT repo. See the Credits table in [`NOTICE.md`](NOTICE.md) for the full list, licenses, and what each informed; see [`docs/ROADMAP.md`](docs/ROADMAP.md) for the technical evaluation.
+## Origin and license
 
-## Project source & credits
+This project is derived from [`memochou1993/gpt-ai-assistant`](https://github.com/memochou1993/gpt-ai-assistant), retains the original MIT license and attribution, and is now independently maintained by SanHsien. See [`NOTICE.md`](NOTICE.md) for detailed provenance and third-party notices.
 
-Upstream replaced its stale News section with a fermi successor pointer in [`d84c806`](https://github.com/memochou1993/gpt-ai-assistant/commit/d84c806b8368ded9d790067235827cdac32a23ab) on June 8, 2026. This project's source lineage includes that version, while its public Git history was reinitialized from the current independently maintained snapshot on July 18, 2026. No upstream contributions are currently planned; see the [roadmap](docs/ROADMAP.md#上游活躍度與回貢決策) for the activity assessment and decision.
-
-Originated from [`memochou1993/gpt-ai-assistant`](https://github.com/memochou1993/gpt-ai-assistant) (by Memo Chou, MIT). Thanks to the original author and all [contributors](https://github.com/memochou1993/gpt-ai-assistant/graphs/contributors). Attribution and third-party notices are in [`NOTICE.md`](NOTICE.md).
-
-## License
-
-[MIT](LICENSE) — original MIT license and upstream attribution preserved. This repo is not switching to FSL-1.1-MIT for now; see [`docs/ROADMAP.md`](docs/ROADMAP.md) for the licensing strategy and future switch conditions.
+Source code is available under the [MIT License](LICENSE). This project is not officially endorsed by LINE, OpenAI, Google, Supabase, Vercel, or any other service provider.

--- a/README.md
+++ b/README.md
@@ -1,185 +1,192 @@
 # GPT AI Assistant
 
-[![Release](https://img.shields.io/github/v/release/SanHsien/gpt-ai-assistant?sort=semver)](https://github.com/SanHsien/gpt-ai-assistant/releases)
+[![Release](https://img.shields.io/github/v/release/SanHsien/gpt-ai-assistant?sort=semver)](https://github.com/SanHsien/gpt-ai-assistant/releases/latest)
 [![CI](https://github.com/SanHsien/gpt-ai-assistant/actions/workflows/ci.yml/badge.svg)](https://github.com/SanHsien/gpt-ai-assistant/actions/workflows/ci.yml)
 [![CodeQL](https://github.com/SanHsien/gpt-ai-assistant/actions/workflows/codeql.yml/badge.svg)](https://github.com/SanHsien/gpt-ai-assistant/actions/workflows/codeql.yml)
-[![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
-[![Node.js 24](https://img.shields.io/badge/node-24-339933.svg)](package.json)
-[![Platform: LINE](https://img.shields.io/badge/platform-LINE-00B900.svg)](https://developers.line.biz/)
-[![Powered by OpenAI](https://img.shields.io/badge/AI-OpenAI-412991.svg)](https://platform.openai.com/)
-[![Tests: Jest](https://img.shields.io/badge/tests-jest-blueviolet.svg)](tests)
-[![Deploy: Vercel](https://img.shields.io/badge/deploy-Vercel-000000.svg)](https://vercel.com/)
+[![Node.js 24](https://img.shields.io/badge/Node.js-24-339933.svg)](package.json)
+[![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
 
-[繁體中文](README.md) | [English](README.en.md)
+[繁體中文](README.md) · [English](README.en.md) · [完整文件站](https://sanhsien.github.io/gpt-ai-assistant-docs/) · [Latest Release](https://github.com/SanHsien/gpt-ai-assistant/releases/latest)
 
-`GPT AI Assistant` 是一個把 **OpenAI** 與 **LINE Messaging API** 串起來的聊天機器人。完成安裝後，你就能在 LINE 手機 app 裡跟自己專屬的 AI 助理對話——聊天、生圖、看圖、上網查資料，全都在 LINE 對話框裡完成。
+**GPT AI Assistant** 是一個可自架的 **LINE 個人 AI 助理**。你用自己的 LINE、OpenAI 與 Supabase 設定部署後，就能直接在 LINE 裡聊天、傳語音或圖片、搜尋資料、管理行程與任務、接收提醒與查天氣。
 
-本 repo 源自 [`memochou1993/gpt-ai-assistant`](https://github.com/memochou1993/gpt-ai-assistant)（MIT），現由 SanHsien 獨立維護。
+它不是另一個聊天介面殼，而是一個以 **LINE 為前端、durable queue 為可靠性核心** 的個人助理服務：付費 AI 工作與 LINE 送達分開 checkpoint，行程、任務與提醒有持久化狀態，Google Calendar／Tasks 可選擇整合。
 
-## 這是什麼
+> **部署、環境變數、Google OAuth、操作教學與疑難排解以 [文件站](https://sanhsien.github.io/gpt-ai-assistant-docs/) 為準。** 本 repo 的 `docs/` 主要保存 runtime、架構、資料契約、migration、技術決策與發行實作。
 
-- **LINE 原生體驗**：不用另外裝 app，直接在 LINE 跟你的助理聊天。
-- **使用者自架、自備金鑰**：用你自己的 OpenAI 與 LINE channel 金鑰部署，資料與帳單都在你手上。
-- **serverless 部署**：以 Vercel 為主，一鍵部署、免顧主機（也可本機 node 或 Docker 自架）。
-- **指令式功能**：除了聊天，還有生圖、看圖、搜尋、翻譯、行程與多種「總結／分析」指令。
+## 適合誰
 
-## 功能一覽
+- 想在 **LINE** 裡使用自己的 AI 助理，而不是再安裝一個聊天 App。
+- 願意自行部署，並使用自己的 OpenAI／LINE／Supabase 憑證與帳單。
+- 需要的不只是聊天，還包括**行程、任務、提醒、搜尋、語音、圖片與天氣**。
+- 重視 serverless 環境下的 webhook 防重送、持久化 queue、重試與資料邊界。
+
+目前正式支援重點是 **繁體中文 (`zh_TW`) + LINE + OpenAI**。英文與日文介面可啟動，但自然語言日期、天氣格式與部分意圖辨識仍以繁體中文為主要驗收基準。
+
+## 核心能力
 
 | 類別 | 能做什麼 |
-|------|----------|
-| 💬 對話 | 與 AI 連續對話（`talk`）；`continue` 續寫、`retry` 重試、`forget` 清除脈絡 |
-| 🎙️ 語音 | 傳 LINE 語音訊息；Windows／Mac 亦可附加 mp3／mp4／mpeg／mpga／m4a／wav／webm 音訊檔。由 OpenAI 語音轉文字（預設 `gpt-4o-mini-transcribe`）後當一般輸入處理 |
-| 🎨 生圖 | 用文字描述請 AI 生圖（`draw`，預設 GPT Image 2） |
-| 👁️ 看圖 | 傳圖片請 AI 理解與描述（vision，預設 `gpt-4o`） |
-| 🔍 搜尋 | 透過 SerpAPI 上網查資料（`search`，需 `SERPAPI_API_KEY`） |
-| 🗓️ 行程與提醒 | 用一句話記行程（`記行程 明天下午三點看診`、`行程 5分鐘後的測試通知`，或直接輸入 `7/20 下午三點牙醫回診`）；模糊時間會先追問，完整草稿確認後才寫入。支援星期解消、`修改行程`、衝突警告、預設提前一天與到點提醒、完成與刪除，並可操作授權的 Google Calendar。開啟 inbound 後，primary calendar 內既存、非 bot 建立的未來單次 timed 行程也會匯入並由 LINE 提醒。提醒可設 `安靜時段 22-8`、`暫停提醒`／`恢復提醒` |
-| ✅ 任務 | 獨立存於 Supabase `tasks` 表的助理待辦，不會建立 Google Calendar 行程；開啟 Google Tasks outbound／inbound並重新授權後，可雙向同步標題、備註、完成、重開與刪除（精確期限仍以本地為準）。有期限任務會預設在一天前與到期時 LINE 提醒；完成、刪除與 Google 端狀態回收會同步取消或重排。`新增任務 重要 明天交報告 #工作` 自動解析期限、優先度與 `#標籤`；用 `我的任務` 及 `今天／明天／本週／下週／逾期／已完成／#標籤` 篩選查看，一鍵完成、重開或刪除（`ENABLE_TASKS`，預設關，需 `DATABASE_URL`） |
-| 🌤️ 天氣 | 查地點天氣與未來預報（`天氣 台北`）；台灣常用縣市簡稱會自動補足行政區與國家。資料來自 Open-Meteo（免費、免 API key），帶短期快取（`ENABLE_WEATHER`，預設關） |
-| 🌐 翻譯 | 翻成英文 / 日文（`translate`） |
-| 🧠 總結／分析 | `sum`（建議、安慰、鼓勵、吐槽…）與 `analyze`（文學、數學、哲學、心理、命理…等角度） |
-| ⚙️ 系統 | `activate` / `deactivate` 啟停、`version` 版本、`report` 回報、`deploy` 自我重新部署、`doc` 說明 |
+| --- | --- |
+| AI 對話 | 連續聊天、續寫、重試、忘記脈絡；模型可由環境變數設定 |
+| 語音與圖片 | LINE 語音／常見音訊檔轉錄、圖片理解、GPT Image 生圖 |
+| 搜尋與網址 | SerpAPI 搜尋；可選 SSRF-safe 網址摘要；搜尋結果附來源連結 |
+| 行程 | 自然語言建立／修改／完成／刪除行程、衝突提示、週期行程、LINE 提醒 |
+| Google Calendar | 授權後可做 outbound CRUD；支援 primary calendar 中安全範圍的 timed non-recurring inbound 同步 |
+| 任務 | Supabase 待辦、期限／優先度／標籤／篩選、完成／重開／刪除與到期提醒 |
+| Google Tasks | 可選 outbound/inbound 狀態同步；精確 due 仍以本地資料為準 |
+| 天氣 | Open-Meteo 現況／預報與可選每日天氣推播，免額外天氣 API key |
+| LINE UX | Feature-aware Quick Reply、確認卡、postback 操作、安靜時段與提醒暫停／恢復 |
 
-> 傳送 `指令` 會依目前啟用的功能，回覆分組完整清單、可直接輸入的指令與範例；文件站另提供完整功能說明。
->
-> 各能力可用環境變數個別關閉以控成本（預設全開）：`ENABLE_IMAGE_GENERATION`、`ENABLE_TRANSCRIPTION`、`ENABLE_VISION`、`ENABLE_SEARCH`。
+可用 feature flags 個別關閉較高成本或非必要功能，例如生圖、語音、vision、搜尋、任務、天氣、Google Calendar／Tasks 等。完整旗標與預設值請看 [文件站](https://sanhsien.github.io/gpt-ai-assistant-docs/) 與 [`.env.example`](.env.example)。
 
-每次一般回覆下方的 LINE Quick Reply 會依功能旗標顯示最多 13 個常用入口：`記行程`、`我的行程`、`新增任務`、`我的任務`、`天氣`、`每日天氣`、`查詢`、`請畫`、`連結 Google 行事曆`、`暫停提醒`、`恢復提醒`、`忘記`、`指令`。LINE 會將 Quick Reply 排成單列橫向捲動，不能由 bot 強制換成兩列。需要手機版固定兩列導覽時，可選用 LINE 官方帳號的 3×2 圖文選單；建議版型、文字動作與避免重複回覆的設定見 [`docs/DEVELOPMENT.md`](docs/DEVELOPMENT.md#line-quick-replies-and-optional-rich-menu)。
+## 使用體驗
 
-部署時可用 `APP_LANG=zh_TW|zh|zh_CN|en|ja` 選擇 bot 介面語系。`zh_TW` 是目前唯一完整驗收、正式支援的語系；`zh` 與 `zh_CN` 暫時共用繁體中文字串，並非簡體中文包；`en`、`ja` 雖可啟動，主要指令與 Google OAuth 頁面已有翻譯，但天氣格式與自然語言日期／意圖辨識仍偏繁中，定位為實驗性，不應對 fork 使用者宣稱完整英／日部署。
+在 LINE 裡可以直接輸入自然語句，例如：
 
-Google Calendar 同步會在背景自動嘗試最多 3 次。成功後才回「已同步到 Google 行事曆」；最終失敗會提供「重試同步」「暫不處理」「刪除行程」。選擇暫不處理會保留 Supabase 資料且不再詢問；之後可用 `同步失敗行程`列出，再用 `重試同步 <ID>` 或 `刪行程 <ID>` 處理。刪除只會在使用者明確選擇後執行。
+```text
+明天下午三點牙醫回診
+新增任務 重要 明天交報告 #工作
+天氣 台北
+搜尋 本週 OpenAI 重要消息
+```
 
-行程快捷鍵使用 LINE postback：對話會顯示「確認行程」或「完成行程 2」這類自然文字，清單操作帶當次序號，但不會附帶 confirmation token、Supabase UUID 或 Google event id。帶 `<ID>` 的文字格式只保留給手動排錯與無法使用按鈕時的備援。
+建立行程時，時間資訊不足會先追問；完整草稿確認後才寫入。Google 同步失敗時會保留本地資料並提供重試／暫不處理／刪除選項，不會因外部服務暫時失敗就直接丟失使用者資料。
 
-行程時間不完整時，bot 只追問一個缺少欄位，下一句自然語句會延續前一張結構化草稿；原始對話不會寫入 Supabase。像「7/20 牙醫回診」這類只有日期的陳述視為整天；「明天下午看診」才會追問幾點。`修改行程` 會列出可修改項目，套用前再確認；版本鎖會拒絕覆蓋已被其他操作更新的行程。時段重疊會警告，但仍由使用者確認。
+LINE 語音訊息或支援的音訊附件會先轉錄，再走與文字相同的輸入流程；建立行程時會回顯轉錄內容，方便辨識「聽錯」與「解析錯」。
 
-## 快速開始（Vercel 優先）
+## 可靠性與資料邊界
 
-1. **準備金鑰**
-   - OpenAI API key（[platform.openai.com](https://platform.openai.com/)）。
-   - LINE Messaging API channel 的 `LINE_CHANNEL_ACCESS_TOKEN` 與 `LINE_CHANNEL_SECRET`（[LINE Developers](https://developers.line.biz/)）。
-   - SerpAPI key（預設開啟搜尋；若不使用搜尋，請設 `ENABLE_SEARCH=false`）。
-   - Supabase Postgres 的 pooler `DATABASE_URL`、CA 與 `DATA_ENCRYPTION_KEY`。
-2. **部署到 Vercel**
-   - 在 Vercel 匯入本 repo。
-   - 到專案設定填入環境變數；6.0 起 LINE、OpenAI、Supabase durable runtime 都是必要前置條件。
-   - 要使用生圖功能，請在 Vercel Storage 建立並連結 Blob store。
-3. **套用資料庫與檢查 runtime**
-   - 先跑 `npm run db:migrate` 套用 `0001`–`0020`，再跑 `npm run db:preflight`。
-4. **設定 LINE webhook**
-   - 部署後取得網址，把 `{你的網址}/webhook` 設為 LINE channel 的 Webhook URL 並啟用。
-5. **開始聊天**
-   - 把 LINE 官方帳號加為好友，傳訊息即可。
+這個專案的工程重點不只在 AI 回答，而在 serverless 環境下避免重複計費、重複訊息與狀態遺失：
 
-Supabase Postgres 與 `0001`–`0020` migrations 是 6.0 的必要 runtime，不再有同步或 Vercel env storage fallback；DB 不可用、缺必要環境變數或 migration 落後時，健康檢查與 webhook 會 fail closed。提醒另以 Supabase Cron 每分鐘呼叫受 secret 保護的 worker endpoint。任務與天氣分別以 `ENABLE_TASKS`、`ENABLE_WEATHER` 開啟。Google Calendar／Tasks 需建立 Web OAuth client、把憑證設為 Vercel Production Sensitive env，並在**同一個 Google Cloud project** 分別啟用 **Google Calendar API** 與 **Google Tasks API**；只有 OAuth scope 不代表 Tasks API 已啟用。請依 [`docs/DEVELOPMENT.md`](docs/DEVELOPMENT.md#完整上線順序) 的上線檢查表操作；**先啟用 API、套 migration 與 Cron，再開 flags 並 Redeploy**。長期使用 Calendar 時應把 OAuth app 發布為 **In Production**，避免 Testing 模式的授權與 refresh token 7 天到期。開啟 `ENABLE_GOOGLE_TASKS` 後須重新傳送 `連結 Google 行事曆`，授予 Tasks scope 並自動回填既有未同步任務；若曾因 API 未啟用而失敗，先啟用 API，再重新連結，`rc.5` 會安全重排同一個 dead sync job，不建立第二筆任務。
+- webhook 先做 durable preflight 與冪等寫入；必要設定、DB 或 migration 異常時 fail closed，讓 LINE redelivery。
+- 「AI 已完成」與「LINE 已送達」是不同 checkpoint；送達重試不重新執行已完成的付費 AI 工作。
+- queue payload 以加密方式保存；使用者／群組狀態使用 deployment-scoped HMAC key，不保存原始 LINE user id 或名稱。
+- 一般對話內容不作為長期個資資料庫保存；需要持久化的是結構化狀態、工作與必要運維資訊。
+- Google Calendar／Tasks 僅在使用者完成 OAuth 授權後操作其授權範圍。
 
-環境變數完整清單見 [`.env.example`](.env.example)；預設值見 `config/index.js`。
+完整 runtime、安全與資料契約請看 [`docs/DEVELOPMENT.md`](docs/DEVELOPMENT.md)、[`docs/DECISIONS.md`](docs/DECISIONS.md) 與 [`REVIEW.md`](REVIEW.md)。
+
+## Google 整合邊界
+
+目前 Calendar 支援 bot 建立／管理的 outbound 行程，以及 primary calendar 中**未來、單次、有時刻**的安全範圍 inbound 同步。以下仍刻意不納入完整同步契約：
+
+- Calendar 全天事件 inbound
+- recurring series / exception inbound
+- 非 primary calendar 匯入
+- Google Tasks due-date inbound 回收
+
+這些限制是明確產品邊界，不代表一般 LINE 行程／任務功能失效。詳細 contract 見 [`docs/ROADMAP.md`](docs/ROADMAP.md)。
+
+## 快速開始
+
+### 1. 準備服務
+
+基本部署需要：
+
+- LINE Messaging API channel
+- OpenAI API key
+- Supabase Postgres
+- Node.js 24
+- Vercel（建議）或可執行 Node/Docker 的環境
+
+搜尋、Google Calendar／Tasks、生圖 Blob 等功能各有額外設定。
+
+### 2. 安裝與檢查
+
+```bash
+git clone https://github.com/SanHsien/gpt-ai-assistant.git
+cd gpt-ai-assistant
+npm ci
+cp .env.example .env
+npm run db:migrate
+npm run db:preflight
+```
+
+### 3. 部署並設定 LINE webhook
+
+部署後，把 LINE channel 的 Webhook URL 指向：
+
+```text
+https://YOUR_HOST/webhook
+```
+
+正式上線前還需要確認 Supabase migrations、Cron、Production Sensitive env，以及你實際啟用功能所需的 API／OAuth。**不要只照 README 猜設定**；請依 [完整部署文件](https://sanhsien.github.io/gpt-ai-assistant-docs/) 的順序操作。
 
 ## 本機開發
 
-需要 Node.js 24。
-
 ```bash
 npm ci
-cp .env.example .env    # 填入你的金鑰
-npm run dev             # nodemon 起本機 Express
-npx eslint .            # ESLint flat config
-npm test                # jest
+cp .env.example .env
+npm run dev
+npx eslint .
+npm run test:module-load
+npm test
 ```
 
-本機起服務後，LINE webhook 需要對外可達的 HTTPS 網址，可用 ngrok / cloudflared 等把本機 port 打通。細節、架構圖與部署說明見 [`docs/DEVELOPMENT.md`](docs/DEVELOPMENT.md)。
+LINE webhook 需要可從 Internet 抵達的 HTTPS URL；本機開發可透過 ngrok、cloudflared 或同類 tunnel 暴露測試端點。
 
-## 專案結構
+CI 另外會建立 production Docker image，啟動容器並驗證 `/health/live` 與 image healthcheck。
+
+## 架構概覽
 
 ```text
-.
-├── api/index.js          # webhook 入口（Vercel serverless / 本機 Express）
-├── app/                  # 事件 → context → handlers/commands（指令實作）
-├── services/             # OpenAI / LINE / Google Calendar / queue 等服務
-├── repositories/         # Supabase Postgres repositories
-├── db/                   # migrations / rollbacks
-├── config/index.js       # 環境變數單一讀取點
-├── constants/ contracts/ locales/ middleware/ utils/
-├── tests/                # jest 測試
-├── docs/                 # ROADMAP / DEVELOPMENT / DECISIONS
-├── REVIEW.md             # 最新一次專案覆核
-├── README.md / README.en.md
-├── AGENTS.md / CLAUDE.md / SKILL.md   # AI 接手指引
-├── NOTICE.md / LICENSE / CHANGELOG.md
-└── Dockerfile / docker-compose.yaml / vercel.json
+LINE
+  │ webhook
+  ▼
+api/index.js
+  │ preflight / durable enqueue / idempotency
+  ▼
+Supabase-backed jobs
+  │
+  ├── OpenAI ── chat / transcription / vision / image
+  ├── SerpAPI ── search
+  ├── Google ── Calendar / Tasks
+  └── Open-Meteo ── weather
+  │
+  ▼
+LINE delivery checkpoint
 ```
 
-## 專案方向與路線圖
+主要程式位置：
 
-本專案維持 **OpenAI + LINE、自架、自備 API key** 的核心，並已決定分階段發展為個人助理；不整套重寫，也不把其他供應商改成預設。完整依賴順序、資料模型、模型／API、參考架構與授權邊界見 [`docs/ROADMAP.md`](docs/ROADMAP.md)。
+- `api/`：HTTP / serverless 入口
+- `app/`：LINE event、context、handlers / commands
+- `services/`：AI、LINE、Google、queue、reminders 等服務
+- `repositories/`：Supabase data access
+- `db/`：migrations / rollbacks
+- `config/index.js`：環境變數單一讀取點
+- `tests/`：Jest 回歸測試
 
-### 已完成
+## 文件分工
 
-- **安全加固**：webhook 缺 `LINE_CHANNEL_SECRET` 時 fail closed、`.env.example` 預設 `APP_DEBUG=false`、加上 CodeQL 掃描與 Dependabot 自動更新、相依漏洞清零。
-- **6 個 bug 修復**：群組 `forget` 沒清歷史、搜尋無結果會 crash、版本指令拖垮整批回覆、健康檢查路由掛住、`stop` sequences 從未送出、語音暫存檔洩漏。
-- **Durable source 狀態**：使用者／群組的啟停狀態只保存 deployment-scoped HMAC 代碼並由 Postgres 原子限制數量；不保存 LINE 原始 ID 或名稱。
-- **升級預設模型**：對話 `gpt-4o-mini`、生圖 `gpt-image-2`（`low` 品質）、語音 `gpt-4o-mini-transcribe`（皆走環境變數可設定）。
-- **能力 feature flags**：`ENABLE_IMAGE_GENERATION` / `ENABLE_TRANSCRIPTION` / `ENABLE_VISION` / `ENABLE_SEARCH` 個別控成本。
-- **對話 TTL**：`APP_MAX_PROMPT_AGE` 讓久未互動的對話 context 自動過期（預設停用，設秒數啟用）。
-- **CI + 徽章**：GitHub Actions 每次 push 跑 eslint + jest；README 顯示 CI / CodeQL 即時狀態徽章。
-- **群組回覆政策**：`GROUP_REPLY_REQUIRES_MENTION` 讓群組需點名才回，減少噪音（預設關）。
-- **LINE 送達 checkpoint**：reply 失敗只重送已保存結果，不重跑付費 AI，也不自動改用計額度的 Push API。
-- **網址摘要**：`ENABLE_URL_SUMMARY`（預設關）遇訊息含網址時，經 SSRF-safe 抓取網頁作為摘要上下文；殘留風險見 [`docs/DEVELOPMENT.md`](docs/DEVELOPMENT.md)。
-- **GPT Image 支援**：預設 `gpt-image-2`，base64 圖片上傳 private Vercel Blob，再以限時 signed URL 交給 LINE；可用環境變數調整模型與品質。設定見 [`docs/DEVELOPMENT.md`](docs/DEVELOPMENT.md)。
-- **Webhook 防重送**：LINE redelivery 與重複 `webhookEventId` 不會再次處理，避免長耗時功能重複計費與回覆。
-- **Durable 基礎（Phase 0）**：Supabase Postgres、原子入列的 webhook 冪等、帶 lease fencing 的 job queue、AES-256-GCM 加密的 job payload、HMAC 化的使用者代碼。6.0 固定走 durable queue；事件缺 ID、DB 故障或 migration 落後時拒絕 ACK，交由 LINE redelivery。
-- **行程與提醒（Phase 1 + Phase 3 + Google Calendar 雙向同步）**：一句話（文字或**語音**）建行程，日期／星期與明確鐘點由程式依使用者時區解消，模糊時間以 durable 結構化草稿追問。`每天 22:40 例行檢查`、`每週五下午三點整理週報` 可直接建立週期草稿，確認卡會明列重複規則。新增與修改都先確認，row lock 與 optimistic version 防重複或過時覆蓋；重疊時先警告。Google 模式可新增、修改回寫、列表、完成與刪除；**inbound 同步**（`ENABLE_GOOGLE_CALENDAR_INBOUND`）的 v3 baseline 會匯入 primary calendar 上既存、非 bot 建立的未來單次 timed 行程，增量修改／刪除會重排／取消 LINE 提醒。
-- **語音建行程（Phase 4）**：LINE 語音訊息或桌面版附加的支援音訊檔，轉錄後走與文字相同的 event-draft→確認流程，確認卡回顯「🎤 我聽到：…」讓使用者分辨聽錯／解析錯。預設上限 25 MiB，可用 `TRANSCRIPTION_MAX_BYTES` 調整；圖片建行程決定不做。
-- **任務（Phase 2 + Google Tasks 雙向同步）**：獨立保存於 Supabase 助理待辦；`ENABLE_GOOGLE_TASKS` 開啟時新增／完成／重開／刪除會同步到 Google Tasks（與 Calendar 共用 OAuth），`ENABLE_GOOGLE_TASKS_INBOUND` 開啟時 Google 端的完成／重開、刪除、標題、備註也會回收到本地（`due` 不回收，精確期限以本地為權威）。自然語言期限依使用者時區解析，支援優先度、標籤、今天／明天／本週／下週／逾期／已完成篩選、分頁，以及 owner-scoped 完成、重開與刪除。未知篩選會回覆可用選項，不會退回全部任務造成假成功。
-- **提醒偏好（Phase 3）**：行程與有期限任務預設在一天前（`REMINDER_OFFSETS=1440`）及到點提醒；可設最多五個提前量，週期行程的每次 occurrence 也會套用。共用安靜時段、暫停／恢復、陳舊提醒跳過與 retry key；無期限任務不排提醒。
-- **天氣（Phase 6）**：Open-Meteo 現況與 1–7 日預報、同名地點座標追問，以及每日訂閱推播（`ENABLE_WEATHER_PUSH`，重用同一 scheduler）。
-- **搜尋來源標註（Phase 7）**：`search` 在 AI 整理段下附「📎 來源」清單（標題／來源站／時間／連結）；來源只顯示、不進 prompt。
-- **Run trace（Phase 0）**：每次 AI 執行記錄能力／模型／token／估算成本／耗時／狀態，不含對話內容或憑證。
-- **Durable checkpoint**：把「AI 已完成」與「LINE 已送達」拆成兩個 checkpoint，語意是 **AI 至多執行一次、送達可重試多次**——失敗重試只會重送，不會重複付費，也不會產生重複訊息。
+### 使用者文件
 
-### 6.x 正式版
+- [完整文件站（繁中）](https://sanhsien.github.io/gpt-ai-assistant-docs/)
+- [English docs](https://sanhsien.github.io/gpt-ai-assistant-docs/en/)
+- [`SanHsien/gpt-ai-assistant-docs`](https://github.com/SanHsien/gpt-ai-assistant-docs)：安裝、部署、設定、使用方式與疑難排解的 source of truth
 
-- **`6.1.0`（目前版本）**：行程提前提醒預設改為**一天前**並保留到點提醒；Calendar inbound v3 的 baseline 會匯入 primary calendar 上既存、未來、非週期且有時刻的 Google-origin 行程（包含非 bot 建立），後續增量新建／修改／刪除會建立、重排或取消 LINE 提醒；**有期限任務**也有同一組提前與到期提醒。另建立 Dependabot 分類、guarded merge 與每月依賴 freshness 的維護閉環。
-- **`6.0.1`**：修正刪除行程只移除 `events`、未同步取消待執行提醒的問題；LINE 刪除與 Google inbound 刪除改為同一原子 SQL。
-- **`6.0.0`**：Supabase durable-only runtime、Google Calendar／Tasks 雙向契約、提醒／週期／搜尋／天氣與桌面音訊入口已完成集中 LINE／Supabase／Google 驗收。語音句首「寄／紀／計／既行程」等同音辨識會安全正規化，原始轉錄仍會回顯供核對。完整證據見 [`REVIEW.md`](REVIEW.md) 與 [`docs/ROADMAP.md`](docs/ROADMAP.md)。
-- **Google contract 邊界**：Calendar outbound CRUD、mapped timed non-recurring inbound，以及 primary calendar 上未來、非週期且有時刻的 Google-origin 行程匯入已納入契約；首次 baseline 會匯入既存安全範圍，後續修改／刪除會重排／取消 LINE 提醒。Calendar 全天 inbound、週期 series／exception、非 primary calendar 匯入，以及 Tasks due 回收仍明確不支援。
-- **模型與 API 進一步升級**——首輪已完成；新模型等待實作前對官方文件重核，見 [`docs/ROADMAP.md`](docs/ROADMAP.md)。
-- **吸收 fermi 架構經驗**——分階段重做可靠性、持久化、觀測性；不直接合併 fermi 原始碼。
-- **Claude 版助理**——未來可能，可能開新專案或在此 repo 分支，方式待定。
+### 本 repo 維護文件
 
-### 已排除方向
+- [`docs/DEVELOPMENT.md`](docs/DEVELOPMENT.md)：runtime 架構、開發、部署實作與驗證
+- [`docs/ROADMAP.md`](docs/ROADMAP.md)：產品邊界、資料／Google contract 與後續方向
+- [`docs/DECISIONS.md`](docs/DECISIONS.md)：技術與產品決策
+- [`REVIEW.md`](REVIEW.md)：最新 evidence-based 專案覆核與未驗證項
+- [`CHANGELOG.md`](CHANGELOG.md)：版本歷史
+- [`NOTICE.md`](NOTICE.md)：來源、attribution 與第三方聲明
 
-- **OpenAI / ChatGPT 訂閱 OAuth 取代 API key**——官方目前將 ChatGPT 訂閱與 API 分開計費與管理；此 repo 不把第三方 LINE bot 設計成消耗 ChatGPT 訂閱額度的 OAuth app。細節見 [`docs/ROADMAP.md`](docs/ROADMAP.md)。
-- **CalDAV / Apple / ICS 互通（原 Phase 5B）**——個人單一 Google 帳號情境下，Google Calendar 雙向同步已覆蓋需求；跨協定互通維護成本高於效益，決定不做。
-- **行程分享與群組協作（原 Phase 8）**——維持個人單人助理定位，不做分享連結與群組權限模型。
-- **多頻道 adapter（原 Phase 9）**——LINE 為唯一主頻道並已最佳化其 UX，不抽多頻道 delivery 抽象。
-- **搜尋主題追蹤主動推播（原 Phase 7 一項）**——搜尋維持使用者主動即問即答，不做定時主題摘要推播。
-- **多來源交叉比對／標註分歧（原 Phase 7 一項）**——需抓來源原文比對事實、CP 值偏低且提高注入與成本風險；搜尋維持單一答案＋來源連結呈現。
-- **圖片（海報／票券／截圖）建行程（原 Phase 4 一項）**——vision 擷取信心／欄位缺漏／多活動確認複雜且受圖片品質影響大；手打或語音已足夠。圖片維持看圖聊天，不接行程擷取。（**語音建行程已實作**。）
-- **批次建立多筆行程（原 Phase 1 一項）**——需多草稿與逐項／整批確認的新狀態機，個人單人情境價值低；逐筆新增或週期行程已覆蓋大部分需求。
+## 專案方向
 
-以上七項於 2026-07-17 決定不實作，詳見 [`docs/ROADMAP.md`](docs/ROADMAP.md) 各 Phase 段落與「明確不做」。
+GPT AI Assistant 維持以下核心：
 
-決策脈絡見 [`docs/DECISIONS.md`](docs/DECISIONS.md)；Phase 狀態與現況見 [`docs/ROADMAP.md`](docs/ROADMAP.md)。
+- **LINE 是唯一主要使用介面**，不抽象成多頻道平台。
+- **OpenAI 是預設 AI provider**，使用者自備 API key。
+- **自架與可驗證的 durable runtime** 優先於增加更多聊天花樣。
+- Google Calendar／Tasks 是個人助理整合，不擴張成多人協作或企業工作流平台。
 
-## 文件
+完整已完成／不做項目與未來規劃見 [`docs/ROADMAP.md`](docs/ROADMAP.md)，不再在 README 重複維護一份平行 roadmap。
 
-- 文件站（中文）：<https://sanhsien.github.io/gpt-ai-assistant-docs/>
-- 文件站（English）：<https://sanhsien.github.io/gpt-ai-assistant-docs/en/>
-- 本 repo 維護文件：[產品路線圖與技術評估](docs/ROADMAP.md)、[開發與部署](docs/DEVELOPMENT.md)、[決策紀錄](docs/DECISIONS.md)
+## 專案來源與授權
 
-> 文件站源自上游 [`memochou1993/gpt-ai-assistant-docs`](https://github.com/memochou1993/gpt-ai-assistant-docs)（VuePress），現獨立維護並以 GitHub Pages 發佈。上游原站：<https://memochou1993.github.io/gpt-ai-assistant-docs/>。
+本專案衍生自 [`memochou1993/gpt-ai-assistant`](https://github.com/memochou1993/gpt-ai-assistant)，保留原始 MIT 授權與 attribution，現由 SanHsien 獨立維護。詳細來源與第三方聲明見 [`NOTICE.md`](NOTICE.md)。
 
-## 其他可參考專案
-
-本專案只就概念、規格或部署流程參考若干服務與開源專案（LINE／OpenAI 官方文件、其他繁中 LINE bot、fermi、Toki 等），**未包含它們的任何原始碼**；GPL／FSL／無授權專案不併入本 MIT repo。完整清單、授權與「各自啟發了什麼」見 [`NOTICE.md`](NOTICE.md) 的 Credits 表；技術評估見 [`docs/ROADMAP.md`](docs/ROADMAP.md)。
-
-## 專案來源與致謝
-
-本專案源自 [`memochou1993/gpt-ai-assistant`](https://github.com/memochou1993/gpt-ai-assistant)（作者 Memo Chou，MIT）。感謝原作者與所有[貢獻者](https://github.com/memochou1993/gpt-ai-assistant/graphs/contributors)。來源、授權與第三方聲明見 [`NOTICE.md`](NOTICE.md)。
-
-上游於 2026-06-08 以 [`d84c806`](https://github.com/memochou1993/gpt-ai-assistant/commit/d84c806b8368ded9d790067235827cdac32a23ab) 將過時的 News 區塊改為 fermi 接班指引；本專案的來源脈絡包含該版本，但公開 Git 歷史已於 2026-07-18 以目前獨立維護快照重新初始化。目前不安排回貢上游，活躍度與決策見 [`docs/ROADMAP.md`](docs/ROADMAP.md#上游活躍度與回貢決策)。
-
-## 授權
-
-[MIT](LICENSE) — 保留原始 MIT 授權與對上游的 attribution。目前不轉 FSL-1.1-MIT；授權策略與未來轉標條件見 [`docs/ROADMAP.md`](docs/ROADMAP.md)。
+程式碼採 [MIT License](LICENSE)。本專案不代表 LINE、OpenAI、Google、Supabase、Vercel 或其他服務官方背書。

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,46 +1,53 @@
 ---
 name: gpt-ai-assistant
-description: 維護 SanHsien/gpt-ai-assistant。本專案是 LINE × OpenAI 個人助理：支援文字、生圖、影像理解、SerpAPI 搜尋、Supabase durable queue、Google Calendar／Tasks 雙向同步、行程、任務、提醒與天氣；目前穩定版為 6.1.0。serverless（Vercel 優先）部署、使用者自架自備金鑰，源自 memochou1993/gpt-ai-assistant（MIT）並獨立維護。
+description: 維護 SanHsien/gpt-ai-assistant：自架 LINE × OpenAI 個人助理，含 Supabase durable runtime、Google Calendar／Tasks、行程、任務、提醒、搜尋、語音、圖片與天氣。
 ---
 
-# gpt-ai-assistant
+# GPT AI Assistant quick index
+
+完整維護規則先讀 [`AGENTS.md`](AGENTS.md)。
 
 ## 何時使用
 
-使用者要維護 `SanHsien/gpt-ai-assistant`，或開發這個 LINE × OpenAI 助理：
+適用於：
 
-- 修 bug、改良既有指令（talk / draw / search / schedule / Google Calendar / sum / analyze / translate / continue / retry / forget / report / version / deploy / doc…）。
-- 擴充新的 LINE 指令或訊息處理。
-- 調整 OpenAI / LINE / SerpAPI 串接與環境變數。
-- 調整 Vercel（或本機）部署流程。
-- 維護 Supabase migrations、每分鐘 worker、Google Calendar／Tasks OAuth 與同步契約。
-
-## 不適用
-
-- 未與維護者確認方向前，替換 AI 供應商（OpenAI → 其他）、引入 Anthropic SDK 或大改指令協定。
-- 把金鑰／模型／webhook 值寫死進程式碼。
-- 代管使用者對話、LINE user id 或任何個資。
-- 宣稱 LINE / OpenAI 官方背書。
+- LINE event / command / Quick Reply 行為
+- OpenAI chat、transcription、vision、image
+- SerpAPI / URL summary / weather
+- Supabase repositories、durable queue、jobs、reminders
+- Google Calendar／Tasks OAuth、outbound / inbound sync contract
+- DB migrations / preflight / rollback
+- Vercel、Docker、CI、CodeQL、Dependabot
 
 ## 快速定位
 
-- `README.md` / `README.en.md`：使用者入口、功能與部署（中文為主）。
-- `REVIEW.md`：最新一次覆核與未驗證項。
-- `NOTICE.md`：fork 來源與授權聲明。
-- `AGENTS.md` / `CLAUDE.md`：AI 接手規則。
-- `api/index.js`：webhook 入口。
-- `app/`：事件 → context → handlers/commands。
-- `config/index.js`：環境變數單一讀取點。
-- `.env.example`：可設定項清單。
-- `repositories/` / `db/`：Supabase data access、migrations 與 rollbacks。
-- `docs/DEVELOPMENT.md`：架構、本機指令、部署。
-- `docs/DECISIONS.md`：決策紀錄。
+- `api/index.js`：webhook / serverless 入口
+- `app/`：events、context、handlers、commands
+- `services/`：AI、LINE、Google、queue、reminders 等服務
+- `repositories/`：Supabase data access
+- `db/`：migrations / rollbacks
+- `contracts/`：provider / sync 契約
+- `config/index.js`：環境變數單一讀取點
+- `.env.example`：可設定項清單
+- `tests/`：Jest 回歸測試
 
-## 完成回報
+## 文件來源
 
-回報時列出：
+- 使用者安裝／部署／設定／操作／疑難排解：`SanHsien/gpt-ai-assistant-docs`
+- runtime／架構／migration／contract／決策／release evidence：本 app repo
+- 最新專案覆核：[`REVIEW.md`](REVIEW.md)
+- 產品／Google contract：[`docs/ROADMAP.md`](docs/ROADMAP.md)
+- 開發與 Production 驗證：[`docs/DEVELOPMENT.md`](docs/DEVELOPMENT.md)
+- 決策：[`docs/DECISIONS.md`](docs/DECISIONS.md)
+- 來源與授權：[`NOTICE.md`](NOTICE.md)
 
-- 修改了哪些檔案。
-- 是否改到指令協定、OpenAI/LINE/SerpAPI 串接、環境變數或部署流程。
-- 執行過哪些驗證（lint / test / 本機實打 webhook）。
-- 是否碰觸已核准的 [`docs/ROADMAP.md`](docs/ROADMAP.md)；有無跳過 durable storage / queue / scheduler 前置條件，或涉及仍需維護者拍板的候選方向。
+## 基本驗證
+
+```bash
+npm ci
+npx eslint .
+npm run test:module-load
+npm test
+```
+
+依變更範圍再追加 migration、dependency policy 或 Production smoke。不要把版本號寫死在本技能檔；目前版本與正式發行以 `package.json`、tags 與 GitHub Releases 為準。

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gpt-ai-assistant",
   "version": "6.1.0",
-  "description": "Self-hosted LINE assistant powered by OpenAI, Supabase, and Google Calendar/Tasks",
+  "description": "Self-hosted LINE personal assistant with OpenAI, durable Supabase state, Google Calendar/Tasks, reminders, search, weather, voice, and vision",
   "type": "module",
   "engines": {
     "node": ">=24.0.0"


### PR DESCRIPTION
## Summary
- rewrite the Traditional Chinese and English READMEs as product-first landing pages
- keep LINE personal-assistant capabilities, durable reliability, Google integration boundaries, and self-hosted/BYO-key positioning clear without duplicating the full roadmap and release evidence
- make `gpt-ai-assistant-docs` the explicit source of truth for user installation, deployment, configuration, usage, and troubleshooting
- simplify `AGENTS.md`, `CLAUDE.md`, and `SKILL.md` so ordinary maintenance does not require broad documentation bookkeeping or a mandatory REVIEW ledger update
- remove the hard-coded stable version from skill metadata and clarify the package description

## Scope
Documentation and metadata only. No runtime logic, dependencies, database migrations, webhook behavior, queue semantics, LINE/OpenAI/Google integrations, feature flags, or deployment workflows changed.

## Validation expected
Existing CI should run ESLint, module-load checks, Jest, Docker image build, `/health/live`, and container healthcheck. CodeQL should cover JavaScript/TypeScript security analysis.